### PR TITLE
fix: case-sensitive localStorage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then in your `gatsby-config.js`:
         clientSideID: '<your-launchdarkly-project-client-side-id>',
         options: {
           // any LaunchDarkly options you may want to implement
-          bootstrap: 'localstorage', // caches flag values in localstorage
+          bootstrap: 'localStorage', // caches flag values in localStorage
         },
       },
     },


### PR DESCRIPTION
According to https://docs.launchdarkly.com/sdk/features/bootstrapping#javascript and the SDK code, `localStorage` is case-sensitive.

This is simply a change to the Readme example, no code has been modified.