### PR TITLE
React 17 support on peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "gatsby": "^3.0.0 || ^4.0.0",
-    "react": "^16.12.0"
+    "react": "^16.12.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "7.16.4",


### PR DESCRIPTION
This plugin works fine with React 17, but it requires installing with `--legacy-peer-deps` flag in projects based on React 17 — the `peerDependencies` version is set to `^16.12.0`. This PR updates the React version in `peerDependencies` to support both React `^16.12` and `^17`.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/README.md#contributing)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
