### PR TITLE
Transfer code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# more about codeowners below:
-# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-
-* @launchdarkly/team-app-platform-product

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package.lock
 .DS_Store
 Thumbs.db
 .idea
+.vscode/


### PR DESCRIPTION
This PR deletes the CODEOWNERS file in .github/CODEOWNERS in favor of the one in the root directory.